### PR TITLE
add support for set weather newLocation, temorary location change

### DIFF
--- a/wundergroundAPI.pm
+++ b/wundergroundAPI.pm
@@ -172,6 +172,15 @@ sub setRetrieveData {
     return 0;
 }
 
+sub setLocation {
+    my ($self,$lat,$long) = @_;
+
+    $self->{lat}            = $lat;
+    $self->{long}           = $long;
+
+    return 0;
+}
+
 sub getFetchTime {
     my $self = shift;
 
@@ -188,9 +197,18 @@ sub _RetrieveDataFromWU($) {
     my $self = shift;
 
     # retrieve data from cache
-    if ( ( time() - $self->{fetchTime} ) < $self->{cachemaxage} ) {
+    if (  ( time() - $self->{fetchTime} ) < $self->{cachemaxage}
+        and $self->{cached}->{lat} == $self->{lat}
+        and $self->{cached}->{long} == $self->{long}
+      )
+    {
         return _CallWeatherCallbackFn($self);
     }
+
+    $self->{cached}->{lat}  = $self->{lat}
+      unless ( $self->{cached}->{lat} == $self->{lat} );
+    $self->{cached}->{long} = $self->{long}
+      unless ( $self->{cached}->{long} == $self->{long} );
 
     my $paramRef = {
         timeout  => 15,


### PR DESCRIPTION
@LeonGaultier: "guten Morgen. Ich habe einen kleinen Patch für die 2undergroundAPI geschrieben. Es gab da die Tage eine Erweiterung in den API's und dem Weather Modul. Es ist nun möglich mittels set Befehl die Location temporär zu überschreiben und so Daten eines anderen Standortes zu beziehen. "